### PR TITLE
Change position for anisotropic refinement with ZoniShifted

### DIFF
--- a/include/InputFunctions/DensityProfileCoefficients/zoniShiftedCoefficients.h
+++ b/include/InputFunctions/DensityProfileCoefficients/zoniShiftedCoefficients.h
@@ -18,5 +18,5 @@ public:
 
 private:
     const double Rmax       = 1.3;
-    const double alpha_jump = 0.7081 * 1.3;
+    const double alpha_jump = 0.678 * 1.3;
 };

--- a/include/InputFunctions/DensityProfileCoefficients/zoniShiftedGyroCoefficients.h
+++ b/include/InputFunctions/DensityProfileCoefficients/zoniShiftedGyroCoefficients.h
@@ -18,5 +18,5 @@ public:
 
 private:
     const double Rmax       = 1.3;
-    const double alpha_jump = 0.7081 * 1.3;
+    const double alpha_jump = 0.678 * 1.3;
 };

--- a/scripts/performance_likwid/plots/plot_data.py
+++ b/scripts/performance_likwid/plots/plot_data.py
@@ -351,7 +351,7 @@ def main():
         x_position = i * socket_size
         plt.axvline(x=x_position, color='darkgray', linestyle='--', linewidth=1.5)
 
-    plt.ylim(bottom= 0.7 * min(solve_compact + setup_compact), top= 1.3 * max(solve_compact + setup_compact))
+    plt.ylim(bottom= 0.678 * min(solve_compact + setup_compact), top= 1.3 * max(solve_compact + setup_compact))
 
     # Labels and title
     plt.yscale('log')

--- a/scripts/performance_likwid/start_likwid_benchmark.sh
+++ b/scripts/performance_likwid/start_likwid_benchmark.sh
@@ -136,7 +136,7 @@ elif [ "$alpha_coeff" -eq 1 ]; then
 elif [ "$alpha_coeff" -eq 2 ]; then
     alpha_jump=$(python3 -c "print(0.4837 * float($Rmax))")
 elif [ "$alpha_coeff" -eq 3 ]; then
-    alpha_jump=$(python3 -c "print(0.7081 * float($Rmax))")
+    alpha_jump=$(python3 -c "print(0.678 * float($Rmax))")
 else
     echo "Invalid value for alpha_coeff: $alpha_coeff"
     exit 1

--- a/scripts/tutorial/run.sh
+++ b/scripts/tutorial/run.sh
@@ -117,7 +117,7 @@ elif [ "$alpha_coeff" -eq 1 ]; then
 elif [ "$alpha_coeff" -eq 2 ]; then
     alpha_jump=$(python3 -c "print(0.4837 * float($Rmax))")
 elif [ "$alpha_coeff" -eq 3 ]; then
-    alpha_jump=$(python3 -c "print(0.7081 * float($Rmax))")
+    alpha_jump=$(python3 -c "print(0.678 * float($Rmax))")
 else
     echo "Invalid value for alpha_coeff: $alpha_coeff"
     exit 1

--- a/scripts/tutorial/sbatch.sh
+++ b/scripts/tutorial/sbatch.sh
@@ -122,7 +122,7 @@ elif [ "$alpha_coeff" -eq 1 ]; then
 elif [ "$alpha_coeff" -eq 2 ]; then
     alpha_jump=$(echo "0.4837 * $Rmax" | bc)
 elif [ "$alpha_coeff" -eq 3 ]; then
-    alpha_jump=$(echo "0.7081 * $Rmax" | bc)
+    alpha_jump=$(echo "0.678 * $Rmax" | bc)
 else
     echo "Invalid value for alpha_coeff: $alpha_coeff"
     exit 1

--- a/tests/DirectSolver/directSolver.cpp
+++ b/tests/DirectSolver/directSolver.cpp
@@ -77,7 +77,7 @@ TEST(DirectSolverTest, directSolver_DirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -132,7 +132,7 @@ TEST(DirectSolverTest, directSolver_AcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -469,7 +469,7 @@ TEST(DirectSolverTest_CzarnyGeometry, DirectSolverDirBC_Interior_CzarnyGeometry)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -516,7 +516,7 @@ TEST(DirectSolverTest_CzarnyGeometry, DirectSolverAcrossOrigin_CzarnyGeometry)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -565,7 +565,7 @@ TEST(DirectSolverTest_CulhamGeometry, DirectSolverDirBC_Interior_CulhamGeometry)
 
     CulhamGeometry domain_geometry(Rmax);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedGyroCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions = std::make_unique<Refined_Boundary_CulhamGeometry>(Rmax);
@@ -608,7 +608,7 @@ TEST(DirectSolverTest_CulhamGeometry, DirectSolverAcrossOrigin_CulhamGeometry)
 
     CulhamGeometry domain_geometry(Rmax);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedGyroCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions = std::make_unique<Refined_Boundary_CulhamGeometry>(Rmax);
@@ -1030,7 +1030,7 @@ TEST(DirectSolverTakeTest_CzarnyGeometry, DirectSolverDirBC_Interior_CzarnyGeome
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1077,7 +1077,7 @@ TEST(DirectSolverTakeTest_CzarnyGeometry, DirectSolverAcrossOrigin_CzarnyGeometr
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1126,7 +1126,7 @@ TEST(DirectSolverTakeTest_CulhamGeometry, DirectSolverDirBC_Interior_CulhamGeome
 
     CulhamGeometry domain_geometry(Rmax);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedGyroCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions = std::make_unique<Refined_Boundary_CulhamGeometry>(Rmax);
@@ -1169,7 +1169,7 @@ TEST(DirectSolverTakeTest_CulhamGeometry, DirectSolverAcrossOrigin_CulhamGeometr
 
     CulhamGeometry domain_geometry(Rmax);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedGyroCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions = std::make_unique<Refined_Boundary_CulhamGeometry>(Rmax);

--- a/tests/DirectSolver/directSolverNoMumps.cpp
+++ b/tests/DirectSolver/directSolverNoMumps.cpp
@@ -75,7 +75,7 @@ TEST(DirectSolverTestNoMumps, directSolver_DirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -130,7 +130,7 @@ TEST(DirectSolverTestNoMumps, directSolver_AcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -467,7 +467,7 @@ TEST(DirectSolverTestNoMumps_CzarnyGeometry, DirectSolverDirBC_Interior_CzarnyGe
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -514,7 +514,7 @@ TEST(DirectSolverTestNoMumps_CzarnyGeometry, DirectSolverAcrossOrigin_CzarnyGeom
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -563,7 +563,7 @@ TEST(DirectSolverTestNoMumps_CulhamGeometry, DirectSolverDirBC_Interior_CulhamGe
 
     CulhamGeometry domain_geometry(Rmax);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedGyroCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions = std::make_unique<Refined_Boundary_CulhamGeometry>(Rmax);
@@ -606,7 +606,7 @@ TEST(DirectSolverTestNoMumps_CulhamGeometry, DirectSolverAcrossOrigin_CulhamGeom
 
     CulhamGeometry domain_geometry(Rmax);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedGyroCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions = std::make_unique<Refined_Boundary_CulhamGeometry>(Rmax);
@@ -1028,7 +1028,7 @@ TEST(DirectSolverTakeCustomLUTest_CzarnyGeometry, DirectSolverDirBC_Interior_Cza
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1075,7 +1075,7 @@ TEST(DirectSolverTakeCustomLUTest_CzarnyGeometry, DirectSolverAcrossOrigin_Czarn
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1124,7 +1124,7 @@ TEST(DirectSolverTakeCustomLUTest_CulhamGeometry, DirectSolverDirBC_Interior_Cul
 
     CulhamGeometry domain_geometry(Rmax);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedGyroCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions = std::make_unique<Refined_Boundary_CulhamGeometry>(Rmax);
@@ -1167,7 +1167,7 @@ TEST(DirectSolverTakeCustomLUTest_CulhamGeometry, DirectSolverAcrossOrigin_Culha
 
     CulhamGeometry domain_geometry(Rmax);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedGyroCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions = std::make_unique<Refined_Boundary_CulhamGeometry>(Rmax);

--- a/tests/ExtrapolatedSmoother/extrapolated_smoother.cpp
+++ b/tests/ExtrapolatedSmoother/extrapolated_smoother.cpp
@@ -57,7 +57,7 @@ TEST(ExtrapolatedSmootherTest, extrapolatedSmoother_DirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -114,7 +114,7 @@ TEST(ExtrapolatedSmootherTest, extrapolatedSmoother_AcossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -174,7 +174,7 @@ TEST(ExtrapolatedSmootherTest, SequentialExtrapolatedSmootherDirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -259,7 +259,7 @@ TEST(ExtrapolatedSmootherTest, ParallelExtrapolatedSmootherDirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -344,7 +344,7 @@ TEST(ExtrapolatedSmootherTest, SequentialExtrapolatedSmootherAcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -429,7 +429,7 @@ TEST(ExtrapolatedSmootherTest, ParallelExtrapolatedSmootherAcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -513,7 +513,7 @@ TEST(ExtrapolatedSmootherTest, SequentialExtrapolatedSmootherDirBC_Interior_Smal
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -597,7 +597,7 @@ TEST(ExtrapolatedSmootherTest, ParallelExtrapolatedSmootherDirBC_Interior_Smalle
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -681,7 +681,7 @@ TEST(ExtrapolatedSmootherTest, SequentialExtrapolatedSmootherAcrossOrigin_Smalle
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -765,7 +765,7 @@ TEST(ExtrapolatedSmootherTest, ParallelExtrapolatedSmootherAcrossOrigin_Smallest
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -852,7 +852,7 @@ TEST(ExtrapolatedSmootherTest, SequentialExtrapolatedSmootherTakeDirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -937,7 +937,7 @@ TEST(ExtrapolatedSmootherTest, ParallelExtrapolatedSmootherTakeDirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1022,7 +1022,7 @@ TEST(ExtrapolatedSmootherTest, SequentialExtrapolatedSmootherTakeAcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1107,7 +1107,7 @@ TEST(ExtrapolatedSmootherTest, ParallelExtrapolatedSmootherTakeAcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1191,7 +1191,7 @@ TEST(ExtrapolatedSmootherTest, SequentialExtrapolatedSmootherTakeDirBC_Interior_
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1275,7 +1275,7 @@ TEST(ExtrapolatedSmootherTest, ParallelExtrapolatedSmootherTakeDirBC_Interior_Sm
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1359,7 +1359,7 @@ TEST(ExtrapolatedSmootherTest, SequentialExtrapolatedSmootherTakeAcrossOrigin_Sm
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1443,7 +1443,7 @@ TEST(ExtrapolatedSmootherTest, ParallelExtrapolatedSmootherTakeAcrossOrigin_Smal
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =

--- a/tests/Residual/residual.cpp
+++ b/tests/Residual/residual.cpp
@@ -51,7 +51,7 @@ TEST(OperatorATest, applyA_DirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -107,7 +107,7 @@ TEST(OperatorATest, applyA_AcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =

--- a/tests/Smoother/smoother.cpp
+++ b/tests/Smoother/smoother.cpp
@@ -55,7 +55,7 @@ TEST(SmootherTest, smoother_DirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -112,7 +112,7 @@ TEST(SmootherTest, smoother_AcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -172,7 +172,7 @@ TEST(SmootherTest, SequentialSmootherDirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -252,7 +252,7 @@ TEST(SmootherTest, ParallelSmootherDirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -332,7 +332,7 @@ TEST(SmootherTest, SequentialSmootherAcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -412,7 +412,7 @@ TEST(SmootherTest, ParallelSmootherAcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -491,7 +491,7 @@ TEST(SmootherTest, SequentialSmootherDirBC_Interior_SmallestGrid)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -570,7 +570,7 @@ TEST(SmootherTest, ParallelSmootherDirBC_Interior_SmallestGrid)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -649,7 +649,7 @@ TEST(SmootherTest, SequentialSmootherAcrossOrigin_SmallestGrid)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -728,7 +728,7 @@ TEST(SmootherTest, ParallelSmootherAcrossOrigin_SmallestGrid)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -810,7 +810,7 @@ TEST(SmootherTest, SequentialSmootherTakeDirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -890,7 +890,7 @@ TEST(SmootherTest, ParallelSmootherTakeDirBC_Interior)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -970,7 +970,7 @@ TEST(SmootherTest, SequentialSmootherTakeAcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1050,7 +1050,7 @@ TEST(SmootherTest, ParallelSmootherTakeAcrossOrigin)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1129,7 +1129,7 @@ TEST(SmootherTest, SequentialSmootherTakeDirBC_Interior_SmallestGrid)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1208,7 +1208,7 @@ TEST(SmootherTest, ParallelSmootherTakeDirBC_Interior_SmallestGrid)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1287,7 +1287,7 @@ TEST(SmootherTest, SequentialSmootherTakeAcrossOrigin_SmallestGrid)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =
@@ -1366,7 +1366,7 @@ TEST(SmootherTest, ParallelSmootherTakeAcrossOrigin_SmallestGrid)
 
     CzarnyGeometry domain_geometry(Rmax, kappa_eps, delta_e);
 
-    double alpha_jump = 0.7081 * Rmax;
+    double alpha_jump = 0.678 * Rmax;
     std::unique_ptr<DensityProfileCoefficients> coefficients =
         std::make_unique<ZoniShiftedCoefficients>(Rmax, alpha_jump);
     std::unique_ptr<BoundaryConditions> boundary_conditions =


### PR DESCRIPTION
## Merge Request - GuideLine Checklist 

With the old radius of 0.7081, using anisotropic refinement with ZoniShifted led to different grid sizes than with other manufactured problems. Therefore, the radius was slightly reduced to 0.678.

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
Always to be checked:
* [ ] There is at least one issue associated with the pull request.
* [ ] New code adheres with the [coding guidelines](https://github.com/SciCompMod/GMGPolar/wiki)
* [ ] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.

If functions were changed or functionality was added:
* [ ] Tests for new functionality has been added
* [ ] A local test was succesful

If new functionality was added:
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)

If new third party software is used:
* [ ] Did you pay attention to its license? Please remember to add it to the wiki after successful merging.

If new mathematical methods or epidemiological terms are used:
* [ ] Are new methods referenced? Did you provide further documentation?

### Checks by code reviewer(s):
* [ ] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [ ] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [ ] There are appropriate **unit tests** and they pass.
* [ ] The git history is clean and linearized for the merge request. All reviewers should squash commits and write a simple and meaningful commit message.
* [ ] Coverage report for new code is acceptable. 
* [ ] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.