### PR TITLE
Remove hardcoded flags

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,7 +22,7 @@ runs:
       run: |
         mkdir build && cd build
         export CMAKE_PREFIX_PATH=/opt/openmp
-        export CXXFLAGS="-Wall -Wextra -pedantic -Wno-unused -Wno-psabi -Wfloat-conversion"
+        export CXXFLAGS="-Wall -Wextra -pedantic -Wno-unused -Wfloat-conversion"
         cmake -DCMAKE_BUILD_TYPE=Debug -DGMGPOLAR_ENABLE_COVERAGE=ON -DGMGPOLAR_USE_MUMPS=${{ inputs.use-mumps }} ..
         make -j4
     - name: create build dir archive

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,6 +22,7 @@ runs:
       run: |
         mkdir build && cd build
         export CMAKE_PREFIX_PATH=/opt/openmp
+        export CXXFLAGS="-Wall -Wextra -pedantic -Wno-unused -Wno-psabi -Wfloat-conversion"
         cmake -DCMAKE_BUILD_TYPE=Debug -DGMGPOLAR_ENABLE_COVERAGE=ON -DGMGPOLAR_USE_MUMPS=${{ inputs.use-mumps }} ..
         make -j4
     - name: create build dir archive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,6 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
-# Set compiler flags
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -pedantic -Wno-unused -Wno-psabi -Wfloat-conversion")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2 -mtune=generic -Wno-psabi")
-
 # Set coverage compiler flags - must come before any targets are defined
 if(GMGPOLAR_ENABLE_COVERAGE)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -10,6 +10,9 @@ usage() {
     exit 1
 }
 
+export CXX_FLAGS_RELEASE="-O2 -mtune=generic"
+export CXX_FLAGS_DEBUG="-Wall -Wextra -pedantic -Wno-unused -Wfloat-conversion"
+
 # Check if build directory exists in the parent directory
 if [ -d "../build" ]; then
     build_exists=true
@@ -56,7 +59,10 @@ if [ -n "$build_type" ]; then
     echo "Configuring with $build_type build type..."
 
     cmake -S ${PWD}/.. -B ${PWD}/../build \
-        -DCMAKE_BUILD_TYPE="$build_type"  .. || { echo "CMake configuration failed"; exit 1; }
+        -DCMAKE_BUILD_TYPE="$build_type" \
+        -DCMAKE_CXX_FLAGS_RELEASE="${CXX_FLAGS_RELEASE}" \
+        -DCMAKE_CXX_FLAGS_DEBUG="${CXX_FLAGS_DEBUG}" \
+        .. || { echo "CMake configuration failed"; exit 1; }
 fi
 
 cmake --build ${PWD}/../build -j 2


### PR DESCRIPTION
Fixes #231. Flags from Debug mode are removed and hardcoded in the CI workflow. Flags from Release mode are removed (CMake still sets O3 by default. ~~Should `-Wno-psabi` be kept ?~~ The flag `Wno-psabi` is also removed.

## Merge Request - GuideLine Checklist 

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
Always to be checked:
* [x] There is at least one issue associated with the pull request.
* [ ] New code adheres with the [coding guidelines](https://github.com/SciCompMod/GMGPolar/wiki)
* [x] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.

If functions were changed or functionality was added:
* [ ] Tests for new functionality has been added
* [ ] A local test was succesful

If new functionality was added:
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)

If new third party software is used:
* [ ] Did you pay attention to its license? Please remember to add it to the wiki after successful merging.

If new mathematical methods or epidemiological terms are used:
* [ ] Are new methods referenced? Did you provide further documentation?

### Checks by code reviewer(s):
* [x] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [x] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [x] There are appropriate **unit tests** and they pass.
* [x] The git history is clean and linearized for the merge request. All reviewers should squash commits and write a simple and meaningful commit message.
* [x] Coverage report for new code is acceptable. 
* [x] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.