### PR TITLE
Review ebourne cleanup cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if(GMGPOLAR_ENABLE_COVERAGE)
 endif()
 
 find_package(OpenMP REQUIRED COMPONENTS CXX)
-find_package(Kokkos  4.4.1...<5.1 QUIET REQUIRED)
+find_package(Kokkos 4.4.1...<6 QUIET REQUIRED)
 
 if(GMGPOLAR_USE_MUMPS)
     find_package(MUMPS REQUIRED COMPONENTS OpenMP METIS)

--- a/cmake/GMGPolarConfig.cmake.in
+++ b/cmake/GMGPolarConfig.cmake.in
@@ -4,15 +4,15 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(OpenMP REQUIRED)
-find_dependency(Kokkos REQUIRED)
+find_dependency(OpenMP COMPONENTS CXX)
+find_dependency(Kokkos)
 
 if(@GMGPOLAR_USE_MUMPS@)
-    find_dependency(MUMPS REQUIRED)
+    find_dependency(MUMPS COMPONENTS OpenMP METIS)
 endif()
 
 if(@GMGPOLAR_USE_LIKWID@)
-    find_dependency(LIKWID REQUIRED)
+    find_dependency(LIKWID)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/GMGPolarTargets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,9 @@ add_library(GMGPolarLib STATIC
     ${INTERPOLATION_SOURCES}
 )
 
+# Declare C++20 is a minimum required to use GMGPolarLib headers
+target_compile_features(GMGPolarLib INTERFACE cxx_std_20)
+
 # Basic library configuration
 target_include_directories(GMGPolarLib PUBLIC
     ${GMGPOLAR_INCLUDE_DIRS}
@@ -82,6 +85,8 @@ add_library(GMGPolar::GMGPolarLib ALIAS GMGPolarLib)
 add_library(GMGPolarInterface STATIC
     ${CONFIG_PARSER_SOURCES}
 )
+# Declare C++20 is a minimum required to use GMGPolarInterface headers
+target_compile_features(GMGPolarInterface INTERFACE cxx_std_20)
 target_link_libraries(GMGPolarInterface
     PUBLIC
     GMGPolarLib


### PR DESCRIPTION
The review in #214 is a bit difficult to follow, so I decided to open a dedicated PR on the branch of @EmilyBourne.

## Merge Request - GuideLine Checklist 

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
Always to be checked:
* [ ] There is at least one issue associated with the pull request.
* [ ] New code adheres with the [coding guidelines](https://github.com/SciCompMod/GMGPolar/wiki)
* [x] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.

If functions were changed or functionality was added:
* [ ] Tests for new functionality has been added
* [ ] A local test was succesful

If new functionality was added:
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)

If new third party software is used:
* [ ] Did you pay attention to its license? Please remember to add it to the wiki after successful merging.

If new mathematical methods or epidemiological terms are used:
* [ ] Are new methods referenced? Did you provide further documentation?

### Checks by code reviewer(s):
* [ ] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [ ] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [ ] There are appropriate **unit tests** and they pass.
* [ ] The git history is clean and linearized for the merge request. All reviewers should squash commits and write a simple and meaningful commit message.
* [ ] Coverage report for new code is acceptable. 
* [ ] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.