### PR TITLE
Use Default memspace in test polargrid

### DIFF
--- a/src/PolarGrid/polargrid.cpp
+++ b/src/PolarGrid/polargrid.cpp
@@ -34,7 +34,7 @@ PolarGrid<MemorySpace>::PolarGrid(std::vector<double> radii, std::vector<double>
     // Initializes radial_spacings_, angular_spacings_
     initializeDistances();
     // Initializes smoothers splitting radius for circle/radial indexing.
-    initializeLineSplitting(splitting_radius); /**/
+    initializeLineSplitting(splitting_radius);
 }
 
 // Constructor to initialize grid using parameters from GMGPolar.

--- a/src/PolarGrid/polargrid.cpp
+++ b/src/PolarGrid/polargrid.cpp
@@ -34,7 +34,7 @@ PolarGrid<MemorySpace>::PolarGrid(std::vector<double> radii, std::vector<double>
     // Initializes radial_spacings_, angular_spacings_
     initializeDistances();
     // Initializes smoothers splitting radius for circle/radial indexing.
-    initializeLineSplitting(splitting_radius);
+    initializeLineSplitting(splitting_radius); /**/
 }
 
 // Constructor to initialize grid using parameters from GMGPolar.
@@ -191,7 +191,7 @@ void PolarGrid<MemorySpace>::initializeLineSplitting(std::optional<double> split
 {
     auto radii_host(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), radii_));
     if (splitting_radius.has_value()) {
-        if (splitting_radius.value() < radii_(0)) {
+        if (splitting_radius.value() < radii_host(0)) {
             number_smoother_circles_   = 0;
             length_smoother_radial_    = nr();
             smoother_splitting_radius_ = -1.0;
@@ -214,15 +214,14 @@ void PolarGrid<MemorySpace>::initializeLineSplitting(std::optional<double> split
         }
     }
     else {
-        auto h_radius            = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, radii_);
         number_smoother_circles_ = 2; /* We assume numberSmootherCircles_ >= 2 in the further implementation */
         for (int i_r = 2; i_r < nr() - 2;
              i_r++) { /* We assume lengthRadialSmoother_ >= 3 in the further implementation */
             const double uniform_theta_k = (2 * M_PI) / ntheta();
-            const double radial_dist_h   = h_radius[i_r + 1] - h_radius[i_r];
+            const double radial_dist_h   = radii_host[i_r + 1] - radii_host[i_r];
 
             const double q = uniform_theta_k / radial_dist_h;
-            if (q * h_radius[i_r] > 1.0) {
+            if (q * radii_host[i_r] > 1.0) {
                 number_smoother_circles_ = i_r;
                 break;
             }

--- a/tests/PolarGrid/polargrid.cpp
+++ b/tests/PolarGrid/polargrid.cpp
@@ -2,23 +2,73 @@
 #include "../../include/PolarGrid/polargrid.h"
 using namespace gmgpolar;
 
+double compare_coords(PolarGrid<DefaultMemorySpace> grid, Vector<double> expected_r, Vector<double> expected_theta)
+{
+    double r_err     = 0;
+    double theta_err = 0;
+
+    Kokkos::parallel_reduce(
+        "r_test", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, grid.nr()),
+        KOKKOS_LAMBDA(int i_r, double& error) { error += expected_r(i_r) - grid.radius(i_r); }, r_err);
+
+    Kokkos::parallel_reduce(
+        "tetha_test", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, grid.ntheta()),
+        KOKKOS_LAMBDA(int i_theta, double& t_error) { t_error += expected_theta(i_theta) - grid.theta(i_theta); },
+        theta_err);
+
+    return std::max(r_err, theta_err);
+}
+
+double expected_indices(PolarGrid<DefaultMemorySpace> grid)
+{
+
+    double idx_err;
+    Kokkos::parallel_reduce(
+        "indices",
+        Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>({0, 0}, {grid.nr(), grid.ntheta()}),
+        KOKKOS_LAMBDA(const int i, const int j, double& error) {
+            int node_index = grid.index(i, j);
+            int r_out, theta_out;
+            grid.multiIndex(node_index, r_out, theta_out);
+            error += (i - r_out) + (j - theta_out);
+        },
+        idx_err);
+    return idx_err;
+}
+
+double expected_spacing(PolarGrid<DefaultMemorySpace> grid, Vector<double> rad_expected, Vector<double> ang_expected)
+{
+    double radial_spacing_err  = 0;
+    double angular_spacing_err = 0;
+    Kokkos::parallel_reduce(
+        "radial_spacing", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, rad_expected.size()),
+        KOKKOS_LAMBDA(int i_r, double& error) { error += rad_expected(i_r) - grid.radialSpacing(i_r); },
+        radial_spacing_err);
+
+    Kokkos::parallel_reduce(
+        "angular_spacing", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, ang_expected.size()),
+        KOKKOS_LAMBDA(int i_theta, double& error) { error += ang_expected(i_theta) - grid.angularSpacing(i_theta); },
+        angular_spacing_err);
+    return std::max(radial_spacing_err, angular_spacing_err);
+}
+
 TEST(PolarGridTest, DefaultConstructor)
 {
-    PolarGrid<Kokkos::HostSpace> grid;
+    PolarGrid<DefaultMemorySpace> grid;
 }
 
 TEST(PolarGridTest, VectorConstructor)
 {
     std::vector<double> radii  = {0.1, 0.2, 0.5, 0.9, 1.3};
     std::vector<double> angles = {0, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
-    PolarGrid<Kokkos::HostSpace> grid(radii, angles);
+    PolarGrid<DefaultMemorySpace> grid(radii, angles);
 }
 
 TEST(PolarGridTest, NumberOfNodes)
 {
     std::vector<double> radii  = {0.1, 0.2, 0.5, 0.9, 1.3};
     std::vector<double> angles = {0, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
-    PolarGrid<Kokkos::HostSpace> grid(radii, angles);
+    PolarGrid<DefaultMemorySpace> grid(radii, angles);
     ASSERT_EQ(grid.numberOfNodes(), radii.size() * (angles.size() - 1));
 }
 
@@ -26,13 +76,15 @@ TEST(PolarGridTest, AccessorsTest)
 {
     std::vector<double> radii  = {0.1, 0.2, 0.5, 0.9, 1.3};
     std::vector<double> angles = {0, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
-    PolarGrid<Kokkos::HostSpace> grid(radii, angles);
-    ASSERT_DOUBLE_EQ(grid.radius(0), 0.1);
-    ASSERT_DOUBLE_EQ(grid.radius(1), 0.2);
-    ASSERT_DOUBLE_EQ(grid.radius(4), 1.3);
-    ASSERT_DOUBLE_EQ(grid.theta(0), 0);
-    ASSERT_DOUBLE_EQ(grid.theta(1), M_PI / 8);
-    ASSERT_DOUBLE_EQ(grid.theta(4), M_PI + M_PI / 8);
+    PolarGrid<DefaultMemorySpace> grid(radii, angles);
+
+    Kokkos::View<double*, Kokkos::HostSpace> host_vector_radi(radii.data(), radii.size());
+    Kokkos::View<double*, Kokkos::HostSpace> host_vector_angles(angles.data(), angles.size());
+
+    auto expected_radii  = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_radi);
+    auto expected_angles = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_angles);
+
+    ASSERT_DOUBLE_EQ(compare_coords(grid, expected_radii, expected_angles), 0.);
 }
 
 TEST(PolarGridTest, GridJumpTest)
@@ -40,7 +92,7 @@ TEST(PolarGridTest, GridJumpTest)
     std::vector<double> radii  = {0.1, 0.2, 0.5, 0.9, 1.3};
     std::vector<double> angles = {0, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
     double splitting_radius    = 0.4;
-    PolarGrid<Kokkos::HostSpace> grid(radii, angles, splitting_radius);
+    PolarGrid<DefaultMemorySpace> grid(radii, angles, splitting_radius);
     ASSERT_DOUBLE_EQ(grid.radius(0), 0.1);
     ASSERT_DOUBLE_EQ(grid.radius(1), 0.2);
     ASSERT_DOUBLE_EQ(grid.radius(4), 1.3);
@@ -55,17 +107,9 @@ TEST(PolarGridTest, IndexingTest)
     std::vector<double> angles = {
         0, M_PI / 16, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 16, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
     double splitting_radius = 0.6;
-    PolarGrid<Kokkos::HostSpace> grid(radii, angles, splitting_radius);
+    PolarGrid<DefaultMemorySpace> grid(radii, angles, splitting_radius);
 
-    for (int i = 0; i < grid.nr(); i++) {
-        for (int j = 0; j < grid.ntheta(); j++) {
-            int node_index = grid.index(i, j);
-            int r_out, theta_out;
-            grid.multiIndex(node_index, r_out, theta_out);
-            ASSERT_EQ(i, r_out);
-            ASSERT_EQ(j, theta_out);
-        }
-    }
+    ASSERT_EQ(expected_indices(grid), 0.);
 
     for (int i = 0; i < grid.numberOfNodes(); i++) {
         int r_out, theta_out;
@@ -81,7 +125,7 @@ TEST(PolarGridTest, IndexingValuesTest)
     std::vector<double> angles = {
         0, M_PI / 16, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 16, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
     double splitting_radius = 0.6;
-    PolarGrid<Kokkos::HostSpace> grid(radii, angles, splitting_radius);
+    PolarGrid<DefaultMemorySpace> grid(radii, angles, splitting_radius);
 
     {
         int node_index = grid.index(2, 6);
@@ -126,7 +170,7 @@ TEST(PolarGridTest, CoordinatesTest)
     std::vector<double> angles = {
         0, M_PI / 16, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 16, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
     double splitting_radius = 0.6;
-    PolarGrid<Kokkos::HostSpace> grid(radii, angles, splitting_radius);
+    PolarGrid<DefaultMemorySpace> grid(radii, angles, splitting_radius);
 
     ASSERT_DOUBLE_EQ(grid.radius(3), 0.5);
     ASSERT_DOUBLE_EQ(grid.theta(2), M_PI / 8);
@@ -140,15 +184,18 @@ TEST(PolarGridTest, SpacingTest)
     std::vector<double> radii  = {0.1, 0.2, 0.25, 0.5, 0.8, 0.9, 1.3, 1.4, 2.0};
     std::vector<double> angles = {
         0, M_PI / 16, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 16, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
-    PolarGrid<Kokkos::HostSpace> grid(radii, angles);
+    PolarGrid<DefaultMemorySpace> grid(radii, angles);
+    HostVector<double> h_exp_rad_spacing("h_rad_spacing", grid.nr() - 1);
+    HostVector<double> h_exp_theta_spacing("h_theta_spacing", grid.ntheta() - 1);
+    for (int i_r = 0; i_r < grid.nr() - 1; i_r++) {
+        h_exp_rad_spacing(i_r) = radii[i_r + 1] - radii[i_r];
+    }
+    for (int i_theta = 0; i_theta < grid.ntheta() - 1; i_theta++) {
+        h_exp_theta_spacing(i_theta) = angles[i_theta + 1] - angles[i_theta];
+    }
+    auto exp_rad_spacing   = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), h_exp_rad_spacing);
+    auto exp_theta_spacing = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), h_exp_theta_spacing);
 
-    // Test radial spacings
-    ASSERT_DOUBLE_EQ(grid.radialSpacing(0), 0.2 - 0.1);
-    ASSERT_DOUBLE_EQ(grid.radialSpacing(1), 0.25 - 0.2);
-    ASSERT_DOUBLE_EQ(grid.radialSpacing(2), 0.5 - 0.25);
-
-    // Test angular spacings
-    ASSERT_DOUBLE_EQ(grid.angularSpacing(0), M_PI / 16 - 0);
-    ASSERT_DOUBLE_EQ(grid.angularSpacing(1), M_PI / 8 - M_PI / 16);
-    ASSERT_DOUBLE_EQ(grid.angularSpacing(2), M_PI / 2 - M_PI / 8);
+    // Test radial and angular spacings
+    ASSERT_EQ(expected_spacing(grid, exp_rad_spacing, exp_theta_spacing), 0.);
 }

--- a/tests/PolarGrid/polargrid.cpp
+++ b/tests/PolarGrid/polargrid.cpp
@@ -4,8 +4,8 @@ using namespace gmgpolar;
 
 double compare_coords(PolarGrid<DefaultMemorySpace> grid, std::vector<double> radii, std::vector<double> angles)
 {
-    Kokkos::View<double*, Kokkos::HostSpace> host_vector_radi(radii.data(), radii.size());
-    Kokkos::View<double*, Kokkos::HostSpace> host_vector_angles(angles.data(), angles.size());
+    HostVector<double> host_vector_radi(radii.data(), radii.size());
+    HostVector<double> host_vector_angles(angles.data(), angles.size());
 
     auto expected_r     = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_radi);
     auto expected_theta = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_angles);

--- a/tests/PolarGrid/polargrid.cpp
+++ b/tests/PolarGrid/polargrid.cpp
@@ -2,59 +2,82 @@
 #include "../../include/PolarGrid/polargrid.h"
 using namespace gmgpolar;
 
-double compare_coords(PolarGrid<DefaultMemorySpace> grid, std::vector<double> radii, std::vector<double> angles)
+double compare_radial_coords(PolarGrid<DefaultMemorySpace> grid, std::vector<double> radii)
 {
     HostVector<double> host_vector_radi(radii.data(), radii.size());
-    HostVector<double> host_vector_angles(angles.data(), angles.size());
-
-    auto expected_r     = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_radi);
-    auto expected_theta = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_angles);
-
-    double r_err     = 0;
-    double theta_err = 0;
-
+    auto expected_r = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_radi);
+    double r_err    = 0;
     Kokkos::parallel_reduce(
         "r_test", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, grid.nr()),
-        KOKKOS_LAMBDA(int i_r, double& error) { error += expected_r(i_r) - grid.radius(i_r); }, r_err);
-
-    Kokkos::parallel_reduce(
-        "tetha_test", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, grid.ntheta()),
-        KOKKOS_LAMBDA(int i_theta, double& t_error) { t_error += expected_theta(i_theta) - grid.theta(i_theta); },
-        theta_err);
-
-    return std::max(r_err, theta_err);
+        KOKKOS_LAMBDA(int i_r, double& max_error) {
+            double current_err = Kokkos::abs(expected_r(i_r) - grid.radius(i_r));
+            if (current_err > max_error) {
+                max_error = current_err;
+            }
+        },
+        Kokkos::Max<double>(r_err));
+    return r_err;
 }
 
-double expected_indices(PolarGrid<DefaultMemorySpace> grid)
+double compare_angular_coords(PolarGrid<DefaultMemorySpace> grid, std::vector<double> angles)
 {
+    HostVector<double> host_vector_angles(angles.data(), angles.size());
+    auto expected_theta = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_angles);
+    double theta_err    = 0;
+    Kokkos::parallel_reduce(
+        "theta_test", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, grid.ntheta()),
+        KOKKOS_LAMBDA(int i_theta, double& max_error) {
+            double current_err = Kokkos::abs(expected_theta(i_theta) - grid.theta(i_theta));
+            if (current_err > max_error) {
+                max_error = current_err;
+            }
+        },
+        Kokkos::Max<double>(theta_err));
+    return theta_err;
+}
 
-    double idx_err;
+int expected_indices(PolarGrid<DefaultMemorySpace> grid)
+{
+    double idx_err = 0;
     Kokkos::parallel_reduce(
         "indices",
         Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>({0, 0}, {grid.nr(), grid.ntheta()}),
-        KOKKOS_LAMBDA(const int i, const int j, double& error) {
+        KOKKOS_LAMBDA(const int i, const int j, double& max_error) {
             int node_index = grid.index(i, j);
             int r_out, theta_out;
             grid.multiIndex(node_index, r_out, theta_out);
-            error += (i - r_out) + (j - theta_out);
+            double current_err = Kokkos::abs(i - r_out) + Kokkos::abs(j - theta_out);
+            if (current_err > max_error) {
+                max_error = current_err;
+            }
         },
-        idx_err);
+        Kokkos::Max<double>(idx_err));
     return idx_err;
 }
 
 double expected_spacing(PolarGrid<DefaultMemorySpace> grid, Vector<double> rad_expected, Vector<double> ang_expected)
 {
-    double radial_spacing_err  = 0;
-    double angular_spacing_err = 0;
+    double radial_spacing_err = 0;
     Kokkos::parallel_reduce(
         "radial_spacing", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, rad_expected.size()),
-        KOKKOS_LAMBDA(int i_r, double& error) { error += rad_expected(i_r) - grid.radialSpacing(i_r); },
-        radial_spacing_err);
+        KOKKOS_LAMBDA(int i_r, double& max_error) {
+            double r_error = Kokkos::abs(rad_expected(i_r) - grid.radialSpacing(i_r));
+            if (r_error > max_error) {
+                max_error = r_error;
+            }
+        },
+        Kokkos::Max<double>(radial_spacing_err));
 
+    double angular_spacing_err = 0;
     Kokkos::parallel_reduce(
         "angular_spacing", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, ang_expected.size()),
-        KOKKOS_LAMBDA(int i_theta, double& error) { error += ang_expected(i_theta) - grid.angularSpacing(i_theta); },
-        angular_spacing_err);
+        KOKKOS_LAMBDA(int i_theta, double& max_error) {
+            double t_error = Kokkos::abs(ang_expected(i_theta) - grid.angularSpacing(i_theta));
+            if (t_error > max_error) {
+                max_error = t_error;
+            }
+        },
+        Kokkos::Max<double>(angular_spacing_err));
     return std::max(radial_spacing_err, angular_spacing_err);
 }
 
@@ -84,7 +107,8 @@ TEST(PolarGridTest, AccessorsTest)
     std::vector<double> angles = {0, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
     PolarGrid<DefaultMemorySpace> grid(radii, angles);
 
-    ASSERT_DOUBLE_EQ(compare_coords(grid, radii, angles), 0.);
+    ASSERT_DOUBLE_EQ(compare_radial_coords(grid, radii), 0.);
+    ASSERT_DOUBLE_EQ(compare_angular_coords(grid, angles), 0.);
 }
 
 TEST(PolarGridTest, GridJumpTest)
@@ -94,7 +118,8 @@ TEST(PolarGridTest, GridJumpTest)
     double splitting_radius    = 0.4;
     PolarGrid<DefaultMemorySpace> grid(radii, angles, splitting_radius);
 
-    ASSERT_DOUBLE_EQ(compare_coords(grid, radii, angles), 0.);
+    ASSERT_DOUBLE_EQ(compare_radial_coords(grid, radii), 0.);
+    ASSERT_DOUBLE_EQ(compare_angular_coords(grid, angles), 0.);
 }
 
 TEST(PolarGridTest, IndexingTest)
@@ -168,7 +193,8 @@ TEST(PolarGridTest, CoordinatesTest)
     double splitting_radius = 0.6;
     PolarGrid<DefaultMemorySpace> grid(radii, angles, splitting_radius);
     // Check that coordinates are correct
-    ASSERT_DOUBLE_EQ(compare_coords(grid, radii, angles), 0.);
+    ASSERT_DOUBLE_EQ(compare_radial_coords(grid, radii), 0.);
+    ASSERT_DOUBLE_EQ(compare_angular_coords(grid, angles), 0.);
 }
 
 TEST(PolarGridTest, SpacingTest)

--- a/tests/PolarGrid/polargrid.cpp
+++ b/tests/PolarGrid/polargrid.cpp
@@ -2,8 +2,14 @@
 #include "../../include/PolarGrid/polargrid.h"
 using namespace gmgpolar;
 
-double compare_coords(PolarGrid<DefaultMemorySpace> grid, Vector<double> expected_r, Vector<double> expected_theta)
+double compare_coords(PolarGrid<DefaultMemorySpace> grid, std::vector<double> radii, std::vector<double> angles)
 {
+    Kokkos::View<double*, Kokkos::HostSpace> host_vector_radi(radii.data(), radii.size());
+    Kokkos::View<double*, Kokkos::HostSpace> host_vector_angles(angles.data(), angles.size());
+
+    auto expected_r     = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_radi);
+    auto expected_theta = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_angles);
+
     double r_err     = 0;
     double theta_err = 0;
 
@@ -78,13 +84,7 @@ TEST(PolarGridTest, AccessorsTest)
     std::vector<double> angles = {0, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
     PolarGrid<DefaultMemorySpace> grid(radii, angles);
 
-    Kokkos::View<double*, Kokkos::HostSpace> host_vector_radi(radii.data(), radii.size());
-    Kokkos::View<double*, Kokkos::HostSpace> host_vector_angles(angles.data(), angles.size());
-
-    auto expected_radii  = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_radi);
-    auto expected_angles = Kokkos::create_mirror_view_and_copy(DefaultMemorySpace(), host_vector_angles);
-
-    ASSERT_DOUBLE_EQ(compare_coords(grid, expected_radii, expected_angles), 0.);
+    ASSERT_DOUBLE_EQ(compare_coords(grid, radii, angles), 0.);
 }
 
 TEST(PolarGridTest, GridJumpTest)
@@ -93,12 +93,8 @@ TEST(PolarGridTest, GridJumpTest)
     std::vector<double> angles = {0, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
     double splitting_radius    = 0.4;
     PolarGrid<DefaultMemorySpace> grid(radii, angles, splitting_radius);
-    ASSERT_DOUBLE_EQ(grid.radius(0), 0.1);
-    ASSERT_DOUBLE_EQ(grid.radius(1), 0.2);
-    ASSERT_DOUBLE_EQ(grid.radius(4), 1.3);
-    ASSERT_DOUBLE_EQ(grid.theta(0), 0);
-    ASSERT_DOUBLE_EQ(grid.theta(1), M_PI / 8);
-    ASSERT_DOUBLE_EQ(grid.theta(4), M_PI + M_PI / 8);
+
+    ASSERT_DOUBLE_EQ(compare_coords(grid, radii, angles), 0.);
 }
 
 TEST(PolarGridTest, IndexingTest)
@@ -171,12 +167,8 @@ TEST(PolarGridTest, CoordinatesTest)
         0, M_PI / 16, M_PI / 8, M_PI / 2, M_PI, M_PI + M_PI / 16, M_PI + M_PI / 8, M_PI + M_PI / 2, M_PI + M_PI};
     double splitting_radius = 0.6;
     PolarGrid<DefaultMemorySpace> grid(radii, angles, splitting_radius);
-
-    ASSERT_DOUBLE_EQ(grid.radius(3), 0.5);
-    ASSERT_DOUBLE_EQ(grid.theta(2), M_PI / 8);
-
-    ASSERT_DOUBLE_EQ(grid.radius(7), 1.4);
-    ASSERT_DOUBLE_EQ(grid.theta(1), M_PI / 16);
+    // Check that coordinates are correct
+    ASSERT_DOUBLE_EQ(compare_coords(grid, radii, angles), 0.);
 }
 
 TEST(PolarGridTest, SpacingTest)

--- a/tests/PolarGrid/polargrid.cpp
+++ b/tests/PolarGrid/polargrid.cpp
@@ -38,20 +38,20 @@ double compare_angular_coords(PolarGrid<DefaultMemorySpace> grid, std::vector<do
 
 int expected_indices(PolarGrid<DefaultMemorySpace> grid)
 {
-    double idx_err = 0;
+    int idx_err = 0;
     Kokkos::parallel_reduce(
         "indices",
         Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>({0, 0}, {grid.nr(), grid.ntheta()}),
-        KOKKOS_LAMBDA(const int i, const int j, double& max_error) {
+        KOKKOS_LAMBDA(const int i, const int j, int& max_error) {
             int node_index = grid.index(i, j);
             int r_out, theta_out;
             grid.multiIndex(node_index, r_out, theta_out);
-            double current_err = Kokkos::abs(i - r_out) + Kokkos::abs(j - theta_out);
+            int current_err = Kokkos::abs(i - r_out) + Kokkos::abs(j - theta_out);
             if (current_err > max_error) {
                 max_error = current_err;
             }
         },
-        Kokkos::Max<double>(idx_err));
+        Kokkos::Max<int>(idx_err));
     return idx_err;
 }
 


### PR DESCRIPTION
Use only DefaultMemorySpace allocated PolarGrid class in its own tests.
Create device kernels to compute errors.