### PR TITLE
Remove coeff_beta parameter from applyAscOrtho functions

### DIFF
--- a/include/ExtrapolatedSmoother/ExtrapolatedSmootherTake/applyAscOrtho.inl
+++ b/include/ExtrapolatedSmoother/ExtrapolatedSmootherTake/applyAscOrtho.inl
@@ -583,10 +583,10 @@ void ExtrapolatedSmootherTake<LevelCacheType>::applyAscOrthoWhiteRadialSection(C
 
     assert(level_cache.cacheDomainGeometry());
 
-    ConstVector<double> arr        = level_cache.arr();
-    ConstVector<double> att        = level_cache.att();
-    ConstVector<double> art        = level_cache.art();
-    ConstVector<double> detDF      = level_cache.detDF();
+    ConstVector<double> arr   = level_cache.arr();
+    ConstVector<double> att   = level_cache.att();
+    ConstVector<double> art   = level_cache.art();
+    ConstVector<double> detDF = level_cache.detDF();
 
     assert(grid.ntheta() % 2 == 0);
     const int start_white_radials    = 1;

--- a/include/ExtrapolatedSmoother/ExtrapolatedSmootherTake/applyAscOrtho.inl
+++ b/include/ExtrapolatedSmoother/ExtrapolatedSmootherTake/applyAscOrtho.inl
@@ -7,8 +7,7 @@ static KOKKOS_INLINE_FUNCTION void nodeApplyAscOrthoCircleTake(const int i_r, co
                                                                const bool DirBC_Interior, ConstVector<double>& x,
                                                                ConstVector<double>& rhs, Vector<double>& result,
                                                                ConstVector<double>& arr, ConstVector<double>& att,
-                                                               ConstVector<double>& art, ConstVector<double>& detDF,
-                                                               ConstVector<double>& coeff_beta)
+                                                               ConstVector<double>& art, ConstVector<double>& detDF)
 {
     KOKKOS_ASSERT(i_r >= 0 && i_r <= grid.numberSmootherCircles());
 
@@ -185,11 +184,11 @@ static KOKKOS_INLINE_FUNCTION void nodeApplyAscOrthoCircleTake(const int i_r, co
     }
 }
 
-static KOKKOS_INLINE_FUNCTION void
-nodeApplyAscOrthoRadialTake(int i_r, int i_theta, const PolarGrid& grid, bool DirBC_Interior, ConstVector<double>& x,
-                            ConstVector<double>& rhs, Vector<double>& result, ConstVector<double>& arr,
-                            const ConstVector<double>& att, ConstVector<double>& art, const ConstVector<double>& detDF,
-                            ConstVector<double>& coeff_beta)
+static KOKKOS_INLINE_FUNCTION void nodeApplyAscOrthoRadialTake(const int i_r, const int i_theta, const PolarGrid& grid,
+                                                               const bool DirBC_Interior, ConstVector<double>& x,
+                                                               ConstVector<double>& rhs, Vector<double>& result,
+                                                               ConstVector<double>& arr, ConstVector<double>& att,
+                                                               ConstVector<double>& art, ConstVector<double>& detDF)
 {
     assert(i_r >= grid.numberSmootherCircles() - 1 && i_r < grid.nr());
 
@@ -471,14 +470,12 @@ void ExtrapolatedSmootherTake<LevelCacheType>::applyAscOrthoBlackCircleSection(C
     const LevelCacheType& level_cache = ExtrapolatedSmoother<LevelCacheType>::level_cache_;
     const bool DirBC_Interior         = ExtrapolatedSmoother<LevelCacheType>::DirBC_Interior_;
 
-    assert(level_cache.cacheDensityProfileCoefficients());
     assert(level_cache.cacheDomainGeometry());
 
-    ConstVector<double> arr        = level_cache.arr();
-    ConstVector<double> att        = level_cache.att();
-    ConstVector<double> art        = level_cache.art();
-    ConstVector<double> detDF      = level_cache.detDF();
-    ConstVector<double> coeff_beta = level_cache.coeff_beta();
+    ConstVector<double> arr   = level_cache.arr();
+    ConstVector<double> att   = level_cache.att();
+    ConstVector<double> art   = level_cache.art();
+    ConstVector<double> detDF = level_cache.detDF();
 
     /* The outer most circle next to the radial section is defined to be black. */
     const int start_black_circles = (grid.numberSmootherCircles() % 2 == 0) ? 1 : 0;
@@ -493,8 +490,7 @@ void ExtrapolatedSmootherTake<LevelCacheType>::applyAscOrthoBlackCircleSection(C
         // Kokkos lambda function to execute for each point in the index space
         KOKKOS_LAMBDA(const int circle_task, const int i_theta) {
             int i_r = start_black_circles + circle_task * 2;
-            nodeApplyAscOrthoCircleTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF,
-                                        coeff_beta);
+            nodeApplyAscOrthoCircleTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF);
         });
 
     Kokkos::fence();
@@ -511,14 +507,12 @@ void ExtrapolatedSmootherTake<LevelCacheType>::applyAscOrthoWhiteCircleSection(C
     const LevelCacheType& level_cache = ExtrapolatedSmoother<LevelCacheType>::level_cache_;
     const bool DirBC_Interior         = ExtrapolatedSmoother<LevelCacheType>::DirBC_Interior_;
 
-    assert(level_cache.cacheDensityProfileCoefficients());
     assert(level_cache.cacheDomainGeometry());
 
-    ConstVector<double> arr        = level_cache.arr();
-    ConstVector<double> att        = level_cache.att();
-    ConstVector<double> art        = level_cache.art();
-    ConstVector<double> detDF      = level_cache.detDF();
-    ConstVector<double> coeff_beta = level_cache.coeff_beta();
+    ConstVector<double> arr   = level_cache.arr();
+    ConstVector<double> att   = level_cache.att();
+    ConstVector<double> art   = level_cache.art();
+    ConstVector<double> detDF = level_cache.detDF();
 
     /* The outer most circle next to the radial section is defined to be black. */
     const int start_white_circles = (grid.numberSmootherCircles() % 2 == 0) ? 0 : 1;
@@ -533,8 +527,7 @@ void ExtrapolatedSmootherTake<LevelCacheType>::applyAscOrthoWhiteCircleSection(C
         // Kokkos lambda function to execute for each point in the index space
         KOKKOS_LAMBDA(const int circle_task, const int i_theta) {
             const int i_r = start_white_circles + circle_task * 2;
-            nodeApplyAscOrthoCircleTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF,
-                                        coeff_beta);
+            nodeApplyAscOrthoCircleTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF);
         });
 
     Kokkos::fence();
@@ -551,14 +544,12 @@ void ExtrapolatedSmootherTake<LevelCacheType>::applyAscOrthoBlackRadialSection(C
     const LevelCacheType& level_cache = ExtrapolatedSmoother<LevelCacheType>::level_cache_;
     const bool DirBC_Interior         = ExtrapolatedSmoother<LevelCacheType>::DirBC_Interior_;
 
-    assert(level_cache.cacheDensityProfileCoefficients());
     assert(level_cache.cacheDomainGeometry());
 
-    ConstVector<double> arr        = level_cache.arr();
-    ConstVector<double> att        = level_cache.att();
-    ConstVector<double> art        = level_cache.art();
-    ConstVector<double> detDF      = level_cache.detDF();
-    ConstVector<double> coeff_beta = level_cache.coeff_beta();
+    ConstVector<double> arr   = level_cache.arr();
+    ConstVector<double> att   = level_cache.att();
+    ConstVector<double> art   = level_cache.art();
+    ConstVector<double> detDF = level_cache.detDF();
 
     assert(grid.ntheta() % 2 == 0);
     const int start_black_radials    = 0;
@@ -573,8 +564,7 @@ void ExtrapolatedSmootherTake<LevelCacheType>::applyAscOrthoBlackRadialSection(C
         // Kokkos lambda function to execute for each point in the index space
         KOKKOS_LAMBDA(const int radial_task, const int i_r) {
             const int i_theta = start_black_radials + radial_task * 2;
-            nodeApplyAscOrthoRadialTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF,
-                                        coeff_beta);
+            nodeApplyAscOrthoRadialTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF);
         });
 
     Kokkos::fence();
@@ -591,14 +581,12 @@ void ExtrapolatedSmootherTake<LevelCacheType>::applyAscOrthoWhiteRadialSection(C
     const LevelCacheType& level_cache = ExtrapolatedSmoother<LevelCacheType>::level_cache_;
     const bool DirBC_Interior         = ExtrapolatedSmoother<LevelCacheType>::DirBC_Interior_;
 
-    assert(level_cache.cacheDensityProfileCoefficients());
     assert(level_cache.cacheDomainGeometry());
 
     ConstVector<double> arr        = level_cache.arr();
     ConstVector<double> att        = level_cache.att();
     ConstVector<double> art        = level_cache.art();
     ConstVector<double> detDF      = level_cache.detDF();
-    ConstVector<double> coeff_beta = level_cache.coeff_beta();
 
     assert(grid.ntheta() % 2 == 0);
     const int start_white_radials    = 1;
@@ -613,8 +601,7 @@ void ExtrapolatedSmootherTake<LevelCacheType>::applyAscOrthoWhiteRadialSection(C
         // Kokkos lambda function to execute for each point in the index space
         KOKKOS_LAMBDA(const int radial_task, const int i_r) {
             const int i_theta = start_white_radials + radial_task * 2;
-            nodeApplyAscOrthoRadialTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF,
-                                        coeff_beta);
+            nodeApplyAscOrthoRadialTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF);
         });
 
     Kokkos::fence();

--- a/include/Smoother/SmootherTake/applyAscOrtho.inl
+++ b/include/Smoother/SmootherTake/applyAscOrtho.inl
@@ -55,11 +55,11 @@ static KOKKOS_INLINE_FUNCTION void nodeApplyAscOrthoCircleTake(const int i_r, co
     );
 }
 
-static KOKKOS_INLINE_FUNCTION void
-nodeApplyAscOrthoRadialTake(const int i_r, const int i_theta, const PolarGrid& grid, bool DirBC_Interior,
-                            ConstVector<double>& x, ConstVector<double>& rhs, Vector<double>& result,
-                            ConstVector<double>& arr, const ConstVector<double>& att, ConstVector<double>& art,
-                            const ConstVector<double>& detDF)
+static KOKKOS_INLINE_FUNCTION void nodeApplyAscOrthoRadialTake(const int i_r, const int i_theta, const PolarGrid& grid,
+                                                               bool DirBC_Interior, ConstVector<double>& x,
+                                                               ConstVector<double>& rhs, Vector<double>& result,
+                                                               ConstVector<double>& arr, ConstVector<double>& att,
+                                                               ConstVector<double>& art, ConstVector<double>& detDF)
 {
     KOKKOS_ASSERT(i_r >= grid.numberSmootherCircles() && i_r < grid.nr());
 

--- a/include/Smoother/SmootherTake/applyAscOrtho.inl
+++ b/include/Smoother/SmootherTake/applyAscOrtho.inl
@@ -128,10 +128,10 @@ void SmootherTake<LevelCacheType>::applyAscOrthoBlackCircleSection(ConstVector<d
 
     assert(level_cache.cacheDomainGeometry());
 
-    ConstVector<double> arr        = level_cache.arr();
-    ConstVector<double> att        = level_cache.att();
-    ConstVector<double> art        = level_cache.art();
-    ConstVector<double> detDF      = level_cache.detDF();
+    ConstVector<double> arr   = level_cache.arr();
+    ConstVector<double> att   = level_cache.att();
+    ConstVector<double> art   = level_cache.art();
+    ConstVector<double> detDF = level_cache.detDF();
 
     /* The outer most circle next to the radial section is defined to be black. */
     const int start_black_circles = (grid.numberSmootherCircles() % 2 == 0) ? 1 : 0;
@@ -164,10 +164,10 @@ void SmootherTake<LevelCacheType>::applyAscOrthoWhiteCircleSection(ConstVector<d
 
     assert(level_cache.cacheDomainGeometry());
 
-    ConstVector<double> arr        = level_cache.arr();
-    ConstVector<double> att        = level_cache.att();
-    ConstVector<double> art        = level_cache.art();
-    ConstVector<double> detDF      = level_cache.detDF();
+    ConstVector<double> arr   = level_cache.arr();
+    ConstVector<double> att   = level_cache.att();
+    ConstVector<double> art   = level_cache.art();
+    ConstVector<double> detDF = level_cache.detDF();
 
     /* The outer most circle next to the radial section is defined to be black. */
     const int start_white_circles = (grid.numberSmootherCircles() % 2 == 0) ? 0 : 1;
@@ -200,10 +200,10 @@ void SmootherTake<LevelCacheType>::applyAscOrthoBlackRadialSection(ConstVector<d
 
     assert(level_cache.cacheDomainGeometry());
 
-    ConstVector<double> arr        = level_cache.arr();
-    ConstVector<double> att        = level_cache.att();
-    ConstVector<double> art        = level_cache.art();
-    ConstVector<double> detDF      = level_cache.detDF();
+    ConstVector<double> arr   = level_cache.arr();
+    ConstVector<double> att   = level_cache.att();
+    ConstVector<double> art   = level_cache.art();
+    ConstVector<double> detDF = level_cache.detDF();
 
     assert(grid.ntheta() % 2 == 0);
     const int start_black_radials    = 0;
@@ -236,10 +236,10 @@ void SmootherTake<LevelCacheType>::applyAscOrthoWhiteRadialSection(ConstVector<d
 
     assert(level_cache.cacheDomainGeometry());
 
-    ConstVector<double> arr        = level_cache.arr();
-    ConstVector<double> att        = level_cache.att();
-    ConstVector<double> art        = level_cache.art();
-    ConstVector<double> detDF      = level_cache.detDF();
+    ConstVector<double> arr   = level_cache.arr();
+    ConstVector<double> att   = level_cache.att();
+    ConstVector<double> art   = level_cache.art();
+    ConstVector<double> detDF = level_cache.detDF();
 
     assert(grid.ntheta() % 2 == 0);
     const int start_white_radials    = 1;

--- a/include/Smoother/SmootherTake/applyAscOrtho.inl
+++ b/include/Smoother/SmootherTake/applyAscOrtho.inl
@@ -7,8 +7,7 @@ static KOKKOS_INLINE_FUNCTION void nodeApplyAscOrthoCircleTake(const int i_r, co
                                                                bool DirBC_Interior, ConstVector<double>& x,
                                                                ConstVector<double>& rhs, Vector<double>& result,
                                                                ConstVector<double>& arr, ConstVector<double>& att,
-                                                               ConstVector<double>& art, ConstVector<double>& detDF,
-                                                               ConstVector<double>& coeff_beta)
+                                                               ConstVector<double>& art, ConstVector<double>& detDF)
 {
     KOKKOS_ASSERT(i_r >= 0 && i_r < grid.numberSmootherCircles());
 
@@ -60,7 +59,7 @@ static KOKKOS_INLINE_FUNCTION void
 nodeApplyAscOrthoRadialTake(const int i_r, const int i_theta, const PolarGrid& grid, bool DirBC_Interior,
                             ConstVector<double>& x, ConstVector<double>& rhs, Vector<double>& result,
                             ConstVector<double>& arr, const ConstVector<double>& att, ConstVector<double>& art,
-                            const ConstVector<double>& detDF, ConstVector<double>& coeff_beta)
+                            const ConstVector<double>& detDF)
 {
     KOKKOS_ASSERT(i_r >= grid.numberSmootherCircles() && i_r < grid.nr());
 
@@ -127,14 +126,12 @@ void SmootherTake<LevelCacheType>::applyAscOrthoBlackCircleSection(ConstVector<d
     const LevelCacheType& level_cache = Smoother<LevelCacheType>::level_cache_;
     const bool DirBC_Interior         = Smoother<LevelCacheType>::DirBC_Interior_;
 
-    assert(level_cache.cacheDensityProfileCoefficients());
     assert(level_cache.cacheDomainGeometry());
 
     ConstVector<double> arr        = level_cache.arr();
     ConstVector<double> att        = level_cache.att();
     ConstVector<double> art        = level_cache.art();
     ConstVector<double> detDF      = level_cache.detDF();
-    ConstVector<double> coeff_beta = level_cache.coeff_beta();
 
     /* The outer most circle next to the radial section is defined to be black. */
     const int start_black_circles = (grid.numberSmootherCircles() % 2 == 0) ? 1 : 0;
@@ -149,8 +146,7 @@ void SmootherTake<LevelCacheType>::applyAscOrthoBlackCircleSection(ConstVector<d
         // Kokkos lambda function to execute for each point in the index space
         KOKKOS_LAMBDA(const int circle_task, const int i_theta) {
             int i_r = start_black_circles + circle_task * 2;
-            nodeApplyAscOrthoCircleTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF,
-                                        coeff_beta);
+            nodeApplyAscOrthoCircleTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF);
         });
 
     Kokkos::fence();
@@ -166,14 +162,12 @@ void SmootherTake<LevelCacheType>::applyAscOrthoWhiteCircleSection(ConstVector<d
     const LevelCacheType& level_cache = Smoother<LevelCacheType>::level_cache_;
     const bool DirBC_Interior         = Smoother<LevelCacheType>::DirBC_Interior_;
 
-    assert(level_cache.cacheDensityProfileCoefficients());
     assert(level_cache.cacheDomainGeometry());
 
     ConstVector<double> arr        = level_cache.arr();
     ConstVector<double> att        = level_cache.att();
     ConstVector<double> art        = level_cache.art();
     ConstVector<double> detDF      = level_cache.detDF();
-    ConstVector<double> coeff_beta = level_cache.coeff_beta();
 
     /* The outer most circle next to the radial section is defined to be black. */
     const int start_white_circles = (grid.numberSmootherCircles() % 2 == 0) ? 0 : 1;
@@ -188,8 +182,7 @@ void SmootherTake<LevelCacheType>::applyAscOrthoWhiteCircleSection(ConstVector<d
         // Kokkos lambda function to execute for each point in the index space
         KOKKOS_LAMBDA(const int circle_task, const int i_theta) {
             const int i_r = start_white_circles + circle_task * 2;
-            nodeApplyAscOrthoCircleTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF,
-                                        coeff_beta);
+            nodeApplyAscOrthoCircleTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF);
         });
 
     Kokkos::fence();
@@ -205,14 +198,12 @@ void SmootherTake<LevelCacheType>::applyAscOrthoBlackRadialSection(ConstVector<d
     const LevelCacheType& level_cache = Smoother<LevelCacheType>::level_cache_;
     const bool DirBC_Interior         = Smoother<LevelCacheType>::DirBC_Interior_;
 
-    assert(level_cache.cacheDensityProfileCoefficients());
     assert(level_cache.cacheDomainGeometry());
 
     ConstVector<double> arr        = level_cache.arr();
     ConstVector<double> att        = level_cache.att();
     ConstVector<double> art        = level_cache.art();
     ConstVector<double> detDF      = level_cache.detDF();
-    ConstVector<double> coeff_beta = level_cache.coeff_beta();
 
     assert(grid.ntheta() % 2 == 0);
     const int start_black_radials    = 0;
@@ -227,8 +218,7 @@ void SmootherTake<LevelCacheType>::applyAscOrthoBlackRadialSection(ConstVector<d
         // Kokkos lambda function to execute for each point in the index space
         KOKKOS_LAMBDA(const int radial_task, const int i_r) {
             const int i_theta = start_black_radials + radial_task * 2;
-            nodeApplyAscOrthoRadialTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF,
-                                        coeff_beta);
+            nodeApplyAscOrthoRadialTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF);
         });
 
     Kokkos::fence();
@@ -244,14 +234,12 @@ void SmootherTake<LevelCacheType>::applyAscOrthoWhiteRadialSection(ConstVector<d
     const LevelCacheType& level_cache = Smoother<LevelCacheType>::level_cache_;
     const bool DirBC_Interior         = Smoother<LevelCacheType>::DirBC_Interior_;
 
-    assert(level_cache.cacheDensityProfileCoefficients());
     assert(level_cache.cacheDomainGeometry());
 
     ConstVector<double> arr        = level_cache.arr();
     ConstVector<double> att        = level_cache.att();
     ConstVector<double> art        = level_cache.art();
     ConstVector<double> detDF      = level_cache.detDF();
-    ConstVector<double> coeff_beta = level_cache.coeff_beta();
 
     assert(grid.ntheta() % 2 == 0);
     const int start_white_radials    = 1;
@@ -266,8 +254,7 @@ void SmootherTake<LevelCacheType>::applyAscOrthoWhiteRadialSection(ConstVector<d
         // Kokkos lambda function to execute for each point in the index space
         KOKKOS_LAMBDA(const int radial_task, const int i_r) {
             const int i_theta = start_white_radials + radial_task * 2;
-            nodeApplyAscOrthoRadialTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF,
-                                        coeff_beta);
+            nodeApplyAscOrthoRadialTake(i_r, i_theta, grid, DirBC_Interior, x, rhs, temp, arr, att, art, detDF);
         });
 
     Kokkos::fence();


### PR DESCRIPTION
Removed unused parameter 'coeff_beta' from nodeApplyAscOrtho functions.

## Merge Request - GuideLine Checklist 

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
Always to be checked:
* [ ] There is at least one issue associated with the pull request.
* [ ] New code adheres with the [coding guidelines](https://github.com/SciCompMod/GMGPolar/wiki)
* [ ] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.

If functions were changed or functionality was added:
* [ ] Tests for new functionality has been added
* [ ] A local test was succesful

If new functionality was added:
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)

If new third party software is used:
* [ ] Did you pay attention to its license? Please remember to add it to the wiki after successful merging.

If new mathematical methods or epidemiological terms are used:
* [ ] Are new methods referenced? Did you provide further documentation?

### Checks by code reviewer(s):
* [ ] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [ ] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [ ] There are appropriate **unit tests** and they pass.
* [ ] The git history is clean and linearized for the merge request. All reviewers should squash commits and write a simple and meaningful commit message.
* [ ] Coverage report for new code is acceptable. 
* [ ] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.