### PR TITLE
Fix data access on device

### DIFF
--- a/include/GMGPolar/gmgpolar.h
+++ b/include/GMGPolar/gmgpolar.h
@@ -207,8 +207,6 @@ private:
     /* Visualization */
 public: // Public due to cuda restrictions
     void writeToVTK(const std::filesystem::path& file_path, const PolarGrid& grid);
-
-private:
     void writeToVTK(const std::filesystem::path& file_path, const LevelType& level,
                     HostConstVector<double> grid_function);
 };

--- a/include/GMGPolar/utils.h
+++ b/include/GMGPolar/utils.h
@@ -220,8 +220,10 @@ void GMGPolar<DomainGeometry, DensityProfileCoefficients>::writeToVTK(const std:
             Fx(index)    = domain_geometry.Fx(r, theta);
             Fy(index)    = domain_geometry.Fy(r, theta);
         });
+    HostVector<double> Fx_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Fx);
+    HostVector<double> Fy_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Fy);
     for (int index = 0; index < grid.numberOfNodes(); index++) {
-        file << Fx(index) << " " << Fy(index) << " " << 0 << "\n";
+        file << Fx_h(index) << " " << Fy_h(index) << " " << 0 << "\n";
     }
     file << "</DataArray>\n"
          << "</Points>\n";
@@ -280,13 +282,23 @@ void GMGPolar<DomainGeometry, DensityProfileCoefficients>::writeToVTK(const std:
     // Write points
     file << "<Points>\n"
          << "<DataArray type=\"Float64\" NumberOfComponents=\"3\" format=\"ascii\">\n";
-    int i_r, i_theta;
-    double r, theta;
+    Vector<double> Fx("Fx", grid.numberOfNodes());
+    Vector<double> Fy("Fy", grid.numberOfNodes());
+    const DomainGeometry& domain_geometry = domain_geometry_;
+    Kokkos::parallel_for(
+        "collect Fx,Fy", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, grid.numberOfNodes()),
+        KOKKOS_LAMBDA(int index) {
+            int i_r, i_theta;
+            grid.multiIndex(index, i_r, i_theta);
+            double r     = grid.radius(i_r);
+            double theta = grid.theta(i_theta);
+            Fx(index)    = domain_geometry.Fx(r, theta);
+            Fy(index)    = domain_geometry.Fy(r, theta);
+        });
+    HostVector<double> Fx_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Fx);
+    HostVector<double> Fy_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Fy);
     for (int index = 0; index < grid.numberOfNodes(); index++) {
-        grid.multiIndex(index, i_r, i_theta);
-        r     = grid.radius(i_r);
-        theta = grid.theta(i_theta);
-        file << domain_geometry_.Fx(r, theta) << " " << domain_geometry_.Fy(r, theta) << " " << 0 << "\n";
+        file << Fx_h(index) << " " << Fy_h(index) << " " << 0 << "\n";
     }
 
     file << "</DataArray>\n"


### PR DESCRIPTION
This error appeared when running tests with CUDA for https://github.com/spack/spack-packages/pull/5820

## Merge Request - GuideLine Checklist 

**Guideline** to check code before resolve WIP and approval, respectively.
As many checkboxes as possible should be ticked.

### Checks by code author:
Always to be checked:
* [ ] There is at least one issue associated with the pull request.
* [ ] New code adheres with the [coding guidelines](https://github.com/SciCompMod/GMGPolar/wiki)
* [ ] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.

If functions were changed or functionality was added:
* [ ] Tests for new functionality has been added
* [ ] A local test was succesful

If new functionality was added:
* [ ] There is appropriate **documentation** of your work. (use doxygen style comments)

If new third party software is used:
* [ ] Did you pay attention to its license? Please remember to add it to the wiki after successful merging.

If new mathematical methods or epidemiological terms are used:
* [ ] Are new methods referenced? Did you provide further documentation?

### Checks by code reviewer(s):
* [ ] Is the code clean of development artifacts e.g., unnecessary comments, prints, ...
* [ ] The ticket goals for each associated issue are reached or problems are clearly addressed (i.e., a new issue was introduced).
* [ ] There are appropriate **unit tests** and they pass.
* [ ] The git history is clean and linearized for the merge request. All reviewers should squash commits and write a simple and meaningful commit message.
* [ ] Coverage report for new code is acceptable. 
* [ ] No large data files have been added to the repository. Maximum size for files should be of the order of KB not MB. In particular avoid adding of pdf, word, or other files that cannot be change-tracked correctly by git.